### PR TITLE
Make it possible to lookup abuse-c-objects

### DIFF
--- a/uwhoisd/__init__.py
+++ b/uwhoisd/__init__.py
@@ -222,9 +222,11 @@ class UWhois():
             zone = 'ipv6'
         elif query.lower().startswith('as') and query.lower()[2:].isdigit():
             zone = 'asn'
-        # if query is no ip, asn or fqdn
         elif not utils.is_well_formed_fqdn(query):
-            zone = 'abuse-c' # what would  be the correct zone for an abuse-c object
+            # if query is no ip, asn or fqdn 
+            # it's probably a NIC handle (Network Information Centre handle)
+            # probably an abuse-c object
+            zone = 'NIC-handle' 
         else:
             # Domain, strip hostname part if needed
             query, zone = self._strip_hostname(query)

--- a/uwhoisd/__init__.py
+++ b/uwhoisd/__init__.py
@@ -222,6 +222,9 @@ class UWhois():
             zone = 'ipv6'
         elif query.lower().startswith('as') and query.lower()[2:].isdigit():
             zone = 'asn'
+        # if query is no ip, asn or fqdn
+        elif not utils.is_well_formed_fqdn(query):
+            zone = 'abuse-c' # what would  be the correct zone for an abuse-c object
         else:
             # Domain, strip hostname part if needed
             query, zone = self._strip_hostname(query)

--- a/uwhoisd/net.py
+++ b/uwhoisd/net.py
@@ -127,10 +127,11 @@ class ClientHandler(object):
             if self._timed_out:
                 return
             whois_query = self.data.decode().strip().lower()
-            if not utils.is_well_formed_fqdn(whois_query) and ':' not in whois_query and not whois_query.lower().startswith('as'):
-                whois_entry = "; Bad request: '{0}'\r\n".format(whois_query)
-            else:
-                whois_entry = self.query_fct(whois_query)
+            #should all the chekcing be removed?
+            #if not utils.is_well_formed_fqdn(whois_query) and ':' not in whois_query and not whois_query.lower().startswith('as'):
+                # whois_entry = "; Bad request: '{0}'\r\n".format(whois_query)
+            #else:
+            whois_entry = self.query_fct(whois_query)
             yield self.stream.write(whois_entry.encode())
         except tornado.iostream.StreamClosedError:
             logger.warning('Connection closed by %s.', self.client)

--- a/uwhoisd/net.py
+++ b/uwhoisd/net.py
@@ -127,10 +127,6 @@ class ClientHandler(object):
             if self._timed_out:
                 return
             whois_query = self.data.decode().strip().lower()
-            #should all the chekcing be removed?
-            #if not utils.is_well_formed_fqdn(whois_query) and ':' not in whois_query and not whois_query.lower().startswith('as'):
-                # whois_entry = "; Bad request: '{0}'\r\n".format(whois_query)
-            #else:
             whois_entry = self.query_fct(whois_query)
             yield self.stream.write(whois_entry.encode())
         except tornado.iostream.StreamClosedError:


### PR DESCRIPTION
Removing the checking if a query is a fqdn and allowing so to look up NIC-handles (for example for abuse-c objects)